### PR TITLE
Add documentation for persistent and session-specific knowledge base …

### DIFF
--- a/dev_api/knowledge-base-guide.mdx
+++ b/dev_api/knowledge-base-guide.mdx
@@ -24,11 +24,11 @@ CamelAI supports two types of knowledge base entries, each designed for differen
 
 Persistent entries are created through the `/api/v1/knowledge-base/` API endpoint and are tied to your connection IDs. These entries:
 
-- **Persist across all iframes** that use the associated connection ID
-- **Apply globally** to all users and sessions
-- Are ideal for **context that applies universally** across your organization
+- Persist across all iframes that use the associated connection ID
+- Apply globally to all users and sessions
+- Are ideal for context that applies universally across your organization
 
-**Use persistent entries for:**
+Use persistent entries for:
 - Dataset descriptions and schema information
 - Company-wide terminology and metric definitions
 - Standard table relationships and joins
@@ -38,11 +38,11 @@ Persistent entries are created through the `/api/v1/knowledge-base/` API endpoin
 
 Session-specific entries are provided directly in the iframe creation request via the `knowledge_base_entries` parameter. These entries:
 
-- **Only apply to that specific iframe instance**
-- **Do not persist** beyond the iframe's lifecycle
+- Only apply to that specific iframe instance
+- Do not persist beyond the iframe's lifecycle
 - Work alongside any persistent entries you've already created
 
-**Use session-specific entries for:**
+Use session-specific entries for:
 - User-specific instructions (e.g., "This user prefers non-technical explanations")
 - Organization-specific context when serving multiple tenants
 - Temporary overrides or custom behavior for specific sessions
@@ -192,26 +192,3 @@ completed a transaction. Our churn definition is 90+ days of inactivity, and reg
 ## Managing Your Knowledge Base
 
 You can create, read, update, and delete knowledge base entries through the API or through the developer console. Changes take effect immediately for all new conversations.
-
-### Tips for Maintenance
-
-<CardGroup cols={2}>
-<Card title="Regular Reviews" icon="calendar">
-Review and update your knowledge base quarterly to ensure accuracy
-</Card>
-<Card title="Stay Current" icon="arrow-trend-up">
-Add new definitions as your business evolves
-</Card>
-<Card title="Clean Up" icon="trash">
-Remove outdated information to prevent confusion
-</Card>
-<Card title="Test Changes" icon="flask">
-Test the impact of changes using the preview feature in the developer console
-</Card>
-</CardGroup>
-
-## Next Steps
-
-<Card title="Configure Reference Queries" icon="arrow-right" href="/dev_api/reference-query-guide">
-Learn how to set up complex, frequently-used calculations for better performance
-</Card>

--- a/dev_api/knowledge-base-guide.mdx
+++ b/dev_api/knowledge-base-guide.mdx
@@ -16,6 +16,70 @@ The knowledge base is a text area where you define important context about your 
 - Handle time periods and date calculations correctly
 - Understand locale-specific requirements (currency, language, regional formats)
 
+## Persistent vs Session-Specific Knowledge Base Entries
+
+CamelAI supports two types of knowledge base entries, each designed for different use cases:
+
+### Persistent (Stateful) Entries
+
+Persistent entries are created through the `/api/v1/knowledge-base/` API endpoint and are tied to your connection IDs. These entries:
+
+- **Persist across all iframes** that use the associated connection ID
+- **Apply globally** to all users and sessions
+- Are ideal for **context that applies universally** across your organization
+
+**Use persistent entries for:**
+- Dataset descriptions and schema information
+- Company-wide terminology and metric definitions
+- Standard table relationships and joins
+- Data quality notes that affect all users
+
+### Session-Specific (Stateless) Entries
+
+Session-specific entries are provided directly in the iframe creation request via the `knowledge_base_entries` parameter. These entries:
+
+- **Only apply to that specific iframe instance**
+- **Do not persist** beyond the iframe's lifecycle
+- Work alongside any persistent entries you've already created
+
+**Use session-specific entries for:**
+- User-specific instructions (e.g., "This user prefers non-technical explanations")
+- Organization-specific context when serving multiple tenants
+- Temporary overrides or custom behavior for specific sessions
+- Locale preferences (e.g., "Please respond in Spanish")
+
+### Example: Using Session-Specific Entries
+
+When creating an iframe, you can include temporary knowledge base entries that apply only to that session:
+
+```python
+import requests
+
+payload = {
+    "uid": "<string>",
+    "srcs": ["<string>"],
+    "ttl": 900,
+    "knowledge_base_entries": [
+        "This user is new to the tool and has never used SQL before. Please keep answers non-technical",
+        "Please speak in Spanish"
+    ],
+    "model": "gpt-5",
+    "response_mode": "full",
+    "show_sidebar": True
+}
+
+response = requests.post(
+    "https://api.camelai.com/api/v1/iframe/create",
+    headers={
+        "Authorization": "Bearer <token>",
+        "Content-Type": "application/json"
+    },
+    json=payload
+)
+```
+
+These session-specific entries complement (not replace) any persistent knowledge base entries associated with your connection IDs.
+
 ## Best Practices
 
 ### 1. Always Include a Dataset Description

--- a/dev_api/reference-query-guide.mdx
+++ b/dev_api/reference-query-guide.mdx
@@ -17,11 +17,11 @@ CamelAI supports two types of reference queries, each designed for different use
 
 Persistent queries are created through the `/api/v1/reference-queries/` API endpoint and are tied to your connection IDs. These queries:
 
-- **Persist across all iframes** that use the associated connection ID
-- **Apply globally** to all users and sessions
-- Are ideal for **metrics and patterns that apply universally** across your organization
+- Persist across all iframes that use the associated connection ID
+- Apply globally to all users and sessions
+- Are ideal for metrics and patterns that apply universally across your organization
 
-**Use persistent queries for:**
+Use persistent queries for:
 - Standard business metrics and KPIs
 - Dashboard queries used by all users
 - Common table joins and relationships
@@ -31,11 +31,11 @@ Persistent queries are created through the `/api/v1/reference-queries/` API endp
 
 Session-specific queries are provided directly in the iframe creation request via the `reference_queries` parameter. These queries:
 
-- **Only apply to that specific iframe instance**
-- **Do not persist** beyond the iframe's lifecycle
+- Only apply to that specific iframe instance
+- Do not persist beyond the iframe's lifecycle
 - Work alongside any persistent queries you've already created
 
-**Use session-specific queries for:**
+Use session-specific queries for:
 - User-specific data filters (e.g., queries scoped to a specific organization or user)
 - Temporary reference data for specific sessions
 - Custom calculations for individual iframes
@@ -202,11 +202,11 @@ Use language your users will use to ask questions.
 - "complicated_join_v2"
 - "SELECT statement for users"
 
-## Implementation Strategy
+## Ideas for Getting Started
 
 <Steps>
   <Step title="Start with Core Metrics">
-    Add queries for your 5-10 most important KPIs
+    Add queries for your 5-10 most important metrics or user questions
   </Step>
   <Step title="Add Dashboard Queries">
     Include all queries powering existing dashboards
@@ -221,34 +221,3 @@ Use language your users will use to ask questions.
     Monitor what users ask and add missing patterns
   </Step>
 </Steps>
-
-## Maintenance and Optimization
-
-<CardGroup cols={3}>
-  <Card title="Version Control" icon="code-branch">
-    Track changes to critical metric definitions
-  </Card>
-  <Card title="Performance Test" icon="gauge-high">
-    Ensure reference queries run efficiently
-  </Card>
-  <Card title="Regular Review" icon="refresh">
-    Update queries as schema evolves
-  </Card>
-</CardGroup>
-
-- **User Feedback**: Add queries for commonly requested analyses
-- **Clean Up**: Remove outdated or unused queries periodically
-
-## Next Steps
-
-<Tip>
-Start small with your most important metrics, then expand based on user needs.
-</Tip>
-
-1. Identify your most important business metrics
-2. Extract SQL from existing dashboards and reports
-3. Create reference queries with descriptive titles
-4. Test by asking camelAI questions about those metrics
-5. Refine based on accuracy and performance
-
-For general context and definitions, see our [Knowledge Base Guide](/dev_api/knowledge-base-guide).

--- a/dev_api/reference-query-guide.mdx
+++ b/dev_api/reference-query-guide.mdx
@@ -9,6 +9,76 @@ Reference Queries are pre-defined SQL queries that teach camelAI how to calculat
 
 Reference Queries are SQL queries stored in a vectorized database that camelAI searches when processing user questions. Unlike the Knowledge Base which stores textual context, Reference Queries provide actual SQL implementations of your business logic.
 
+## Persistent vs Session-Specific Reference Queries
+
+CamelAI supports two types of reference queries, each designed for different use cases:
+
+### Persistent (Stateful) Queries
+
+Persistent queries are created through the `/api/v1/reference-queries/` API endpoint and are tied to your connection IDs. These queries:
+
+- **Persist across all iframes** that use the associated connection ID
+- **Apply globally** to all users and sessions
+- Are ideal for **metrics and patterns that apply universally** across your organization
+
+**Use persistent queries for:**
+- Standard business metrics and KPIs
+- Dashboard queries used by all users
+- Common table joins and relationships
+- Shared calculation patterns
+
+### Session-Specific (Stateless) Queries
+
+Session-specific queries are provided directly in the iframe creation request via the `reference_queries` parameter. These queries:
+
+- **Only apply to that specific iframe instance**
+- **Do not persist** beyond the iframe's lifecycle
+- Work alongside any persistent queries you've already created
+
+**Use session-specific queries for:**
+- User-specific data filters (e.g., queries scoped to a specific organization or user)
+- Temporary reference data for specific sessions
+- Custom calculations for individual iframes
+- Multi-tenant scenarios where each tenant needs unique query patterns
+
+### Example: Using Session-Specific Reference Queries
+
+When creating an iframe, you can include temporary reference queries that apply only to that session:
+
+```python
+import requests
+
+payload = {
+    "uid": "<string>",
+    "srcs": ["<string>"],
+    "ttl": 900,
+    "reference_queries": [
+        {
+            "title": "Recent Companies",
+            "query": "SELECT * FROM companies ORDER BY batch DESC LIMIT 500;"
+        },
+        {
+            "title": "Company Status Summary",
+            "query": "SELECT status, COUNT(*) AS company_count FROM companies GROUP BY status ORDER BY company_count DESC;"
+        }
+    ],
+    "model": "gpt-5",
+    "response_mode": "full",
+    "show_sidebar": True
+}
+
+response = requests.post(
+    "https://api.camelai.com/api/v1/iframe/create",
+    headers={
+        "Authorization": "Bearer <token>",
+        "Content-Type": "application/json"
+    },
+    json=payload
+)
+```
+
+These session-specific queries complement (not replace) any persistent reference queries associated with your connection IDs.
+
 ## Why Use Reference Queries?
 
 Reference Queries help camelAI:


### PR DESCRIPTION
…and reference queries

This update introduces sections detailing the differences between persistent and session-specific entries for both knowledge base and reference queries. It includes usage guidelines, examples, and best practices to help users understand how to effectively implement these features in their applications.